### PR TITLE
add Dockerfile to run tutorial in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:testing
+
+# suppress debconf bleating about tty
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update; apt-get -y dist-upgrade
+RUN apt-get -y install python3 python3-pip libpython3.5 libxft-dev libfreetype6-dev libpng-dev libfreetype6-dev curl wget apt-utils sudo zlib1g zlib1g-dev libedit2 libedit-dev locales
+
+# install tini, zombie process reaper
+RUN curl -L https://github.com/krallin/tini/releases/download/v0.9.0/tini_0.9.0.deb > /tmp/tini_0.9.0.deb
+RUN dpkg -i /tmp/tini_0.9.0.deb
+RUN apt-get install -y 
+
+# add non-root container user
+ENV NB_USER nlp
+ENV NB_UID 1000
+RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER
+
+RUN pip3 install cython gensim sklearn pandas matplotlib nltk pyemd jupyter
+RUN ipython3 kernel install
+RUN python3 -m nltk.downloader punkt
+
+# install and select fast BLAS, used by Numpy and others
+RUN apt-get install -y libopenblas-base
+RUN update-alternatives --set libblas.so.3 /usr/lib/openblas-base/libblas.so.3
+
+USER $NB_USER
+
+# working data area
+RUN mkdir -p /home/$NB_USER/data
+ENTRYPOINT ["tini", "--"]
+CMD ["/usr/local/bin/jupyter-notebook", "--no-browser", "--ip=0.0.0.0", "--notebook-dir=/home/nlp/"]
+
+EXPOSE 8888
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:testing
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -y update; apt-get -y dist-upgrade
-RUN apt-get -y install python3 python3-pip libpython3.5 libxft-dev libfreetype6-dev libpng-dev libfreetype6-dev curl wget apt-utils sudo zlib1g zlib1g-dev libedit2 libedit-dev locales
+RUN apt-get -y install python3 python3-pip libpython3.5 libxft-dev libfreetype6-dev libpng-dev libfreetype6-dev curl wget apt-utils sudo zlib1g zlib1g-dev libedit2 libedit-dev
 
 # install tini, zombie process reaper
 RUN curl -L https://github.com/krallin/tini/releases/download/v0.9.0/tini_0.9.0.deb > /tmp/tini_0.9.0.deb
@@ -18,7 +18,6 @@ RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER
 
 RUN pip3 install cython gensim sklearn pandas matplotlib nltk pyemd jupyter
 RUN ipython3 kernel install
-RUN python3 -m nltk.downloader punkt
 
 # install and select fast BLAS, used by Numpy and others
 RUN apt-get install -y libopenblas-base
@@ -28,6 +27,8 @@ USER $NB_USER
 
 # working data area
 RUN mkdir -p /home/$NB_USER/data
+RUN python3 -m nltk.downloader punkt
+
 ENTRYPOINT ["tini", "--"]
 CMD ["/usr/local/bin/jupyter-notebook", "--no-browser", "--ip=0.0.0.0", "--notebook-dir=/home/nlp/"]
 


### PR DESCRIPTION
Example build command: `docker build -t rare/nlp .`

This Dockerfile sets up everything except for the working data.  I originally set out to include that but hit two issues.
- For the Google News model, I discovered that I could only get short-lived URLs from Google Drive, which did not work that well when hardcoded in a script.  I think this will be easy to fix for the Google Drive admin.
- The Docker volume stuff is ugly in versions < 1.9, and the working data is a bit unnatural in the image itself.

So in this edition a user must download their own working data on their host machine and then launch the container with a  mapping of that data into /home/nlp/data e.g. as follows

```
docker run -it --rm -p 8888:8888 -v /home/user/tutorial_dir:/home/nlp/data rare/nlp
```

Note the Jupyter port of 8888 forwarded from the host.  This is not always needed but will be simplest for teaching groups.
