### PR TITLE
Fix error "module 'gensim.models.keyedvectors' has no attribute 'load_word2vec_format'"

### DIFF
--- a/Document classification with word embeddings tutorial.ipynb
+++ b/Document classification with word embeddings tutorial.ipynb
@@ -1696,7 +1696,7 @@
    ],
    "source": [
     "%%time \n",
-    "wv = Word2Vec.load_word2vec_format(\n",
+    "wv = Word2Vec.KeyedVectors.load_word2vec_format(\n",
     "    \"~/GoogleNews-vectors-negative300.bin.gz\",\n",
     "    binary=True)\n",
     "wv.init_sims(replace=True)"

--- a/ipynb_with_output/Document classification with word embeddings tutorial - with output.ipynb
+++ b/ipynb_with_output/Document classification with word embeddings tutorial - with output.ipynb
@@ -1686,7 +1686,7 @@
    ],
    "source": [
     "%%time \n",
-    "wv = Word2Vec.load_word2vec_format(\n",
+    "wv = Word2Vec.KeyedVectors.load_word2vec_format(\n",
     "    \"/data/w2v_googlenews/GoogleNews-vectors-negative300.bin.gz\",\n",
     "    binary=True)\n",
     "wv.init_sims(replace=True)"


### PR DESCRIPTION
word2vec.load_word2vec_format -> word2vec.KeyedVectors.load_word2vec_format

Update 2018